### PR TITLE
fix reflection bugs + missing defaulthttpcontent wrapping of str body

### DIFF
--- a/src/net/http/server.clj
+++ b/src/net/http/server.clj
@@ -161,7 +161,7 @@
 
   String
   (chunk->http-object [chunk]
-    (Unpooled/wrappedBuffer (.getBytes chunk "UTF8")))
+    (DefaultHttpContent. (Unpooled/wrappedBuffer (.getBytes chunk "UTF8"))))
 
   HttpContent
   (chunk->http-object [chunk] chunk))
@@ -251,7 +251,7 @@
 (defn backpressure-fn
   "Stop automatically reading from the body channel when we are signalled
    for backpressure."
-  [^ChannelHandlerContext ctx]
+  [ctx]
   (fn [enable?]
     (warn "switching backpressure mode to:" enable?)
     (-> ctx chan/channel .config (.setAutoRead (not enable?)))))


### PR DESCRIPTION
As title says, we were missing a defaulthttpcontent instance wrapper for string bodies and I think I fixed most reflection bugs. But when I am trying the hello world http server example it hangs: 

```
$ curl -vvv http://localhost:8080
* Rebuilt URL to: http://localhost:8080/
* Hostname was NOT found in DNS cache
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET / HTTP/1.1
> User-Agent: curl/7.35.0
> Host: localhost:8080
> Accept: */*
> 
< HTTP/1.1 200 OK
< Content-Type: text/plain
< Content-Length: 6
< 

```

I guess it's time for me to get more familiar with the internals ;) 