### PR TITLE
make response-write executor for simple response maps configurable

### DIFF
--- a/src/net/core/concurrent.clj
+++ b/src/net/core/concurrent.clj
@@ -1,0 +1,31 @@
+(ns net.core.concurrent
+  "Simple wrapper for basic j.u.concurrent tasks (or future alternatives)"
+  (:import
+   (java.util.concurrent
+    Executors
+    ExecutorService
+    Future)))
+
+(defn executor
+  "Returns ExecutorService.
+`type` can be :single, :cached, :fixed or :scheduled, this matches the
+corresponding Java instances"
+  ^ExecutorService
+  ([type] (executor type nil))
+  ([type {:keys [thread-factory num-threads]
+          :or {num-threads 1
+               thread-factory (Executors/defaultThreadFactory)}}]
+   (case type
+     :single (Executors/newSingleThreadExecutor thread-factory)
+     :cached  (Executors/newCachedThreadPool thread-factory)
+     :fixed  (Executors/newFixedThreadPool (int num-threads) thread-factory)
+     :scheduled (Executors/newScheduledThreadPool (int num-threads) thread-factory))))
+
+(defprotocol Executable
+  (submit! [executor-service f]
+    "Submits the fn to specified executor, returns a Future"))
+
+(extend-type ExecutorService
+  Executable
+  (submit! [executor f]
+    (.submit executor ^Callable f)))


### PR DESCRIPTION
It's just a simple proto and a couple of function. The stray `future` call was making me uneasy. The default does exactly the same as master (runs on a cached threadpool), but now at least you can swap with a fixed size executor or something like `ztellman/dirigiste`.