### PR TITLE
Fix problem with multiple-params in query string and body

### DIFF
--- a/src/net/http/server.clj
+++ b/src/net/http/server.clj
@@ -100,7 +100,7 @@
    (map (fn [[stringk vlist]]
           (let [vs (seq vlist)
                 k  (keyword (str stringk))]
-            [k (if (pos? (count vs)) (first vs) vs)])))
+            [k (if (= 1 (count vs)) (first vs) vs)])))
    (.parameters dx)))
 
 (defn qs->body-params


### PR DESCRIPTION
Right now, `net` always takes the `first`, never all, since 1 is a positive number.

Fixes https://github.com/pyr/cyanite/issues/270