### PR TITLE
transforms: add transducers to operate on collections of ByteBufs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ and nothing but standard clojure facilities.
 - HTTP(S) client
 - Simple interface to create TCP server with optional TLS support
 - Clojure [core.async](https://github.com/clojure/core.async) support
+- Memory-efficient transducers for collections of ByteBufs
 
 ## Documentation
 

--- a/src/net/transform/aggregator.clj
+++ b/src/net/transform/aggregator.clj
@@ -1,0 +1,73 @@
+(ns net.transform.aggregator
+  "A buffer aggregator, when a number of smaller ByteBuf instances need to
+   be aggregated over a larger CompositeByteBuf instance.
+
+   These aggregated views rely on the underlying buf and handle memory
+   accounting for it, releasing the aggregated view will release the
+   underlying buffers they are composed of."
+  (:require [net.ty.buffer :as buf]))
+
+(defn aggregate
+  "Offer a new buffer for aggregation, yielding a vector
+   of bytes kept and buffers to yield if any. We may yield
+   several buffers if the aggregation size is smaller than
+   the buffer we were offered."
+  [store buf max-size]
+  (loop [kept (first store)
+         bufs []]
+    (let [kept-len   (if kept (buf/readable-bytes kept) 0)
+          buf-len    (buf/readable-bytes buf)
+          total-len  (+ kept-len buf-len)
+          slice-len  (- (min max-size total-len) kept-len)
+          kept-buf   #(or kept (buf/composite))]
+      (cond
+        (buf/exhausted? buf)
+        [kept bufs]
+
+        (= total-len max-size)
+        [nil (conj bufs (cond->> (buf/read-retained-slice buf)
+                          (some? kept) (buf/augment-composite kept)))]
+
+        (> total-len max-size)
+        (let [slice (buf/read-retained-slice buf slice-len)]
+          (recur
+           nil
+           (conj bufs (cond->> slice (some? kept) (buf/augment-composite kept)))))
+
+        ::else
+        [(buf/augment-composite (kept-buf) (buf/read-retained-slice buf)) bufs]))))
+
+(defn raw-aggregator
+  "A transducer that yields collections of ByteBuf instances from
+   another collection of ByteBuf instances, in the output collection
+   all but the last element of the collection will contain ByteBuf
+   instances of `max-size` bytes. The last one may be smaller."
+  [max-size]
+  (fn [xf]
+    (let [store (volatile! nil)]
+      (fn
+        ([] (xf))
+        ([result]
+         (if-let [tail (first @store)]
+           (xf (unreduced (xf result [tail])))
+           (xf result)))
+        ([result input]
+         (let [[_ bufs] (vswap! store aggregate input max-size)]
+           (buf/release input)
+           (if (seq bufs)
+             (xf result bufs)
+             result)))))))
+
+(defn aggregator
+  "Facility function to create an aggregator which yields a single
+   collection of ByteBuf instances."
+  [max-size]
+  (comp (raw-aggregator max-size) cat))
+
+(def default-chunk-size
+  "Documentation suggests 16 mega bytes is the ideal size."
+  (* 1024 1024 16))
+
+(def default-aggregator
+  "Aggregate to the optimal blob size by default."
+  (aggregator default-chunk-size))

--- a/src/net/transform/split.clj
+++ b/src/net/transform/split.clj
@@ -1,0 +1,97 @@
+(ns net.transform.split
+  "A generic splitting transducer for collections of ByteBuf instances
+   To help the splitting process, and to allow other types of splitting
+   to occur, two protocols are provided."
+  (:require [net.ty.buffer :as buf]
+            [net.codec.hex :refer [hex->long]]))
+
+(defprotocol ContentSplitter
+  (offer [this buf]
+    "Augment a splitter instance with a new buffer,
+     yielding a vector of the updated splitter and
+     a new buffer if one was found."))
+
+(defprotocol HeaderParser
+  (header-length [this buf]
+    "Yield length of header needed to compute the length
+     of the split, if possible.")
+  (payload-length [this mark kept buf]
+    "Yield the length of the full split payload, this
+     assumes header-length was called and returned."))
+
+(defprotocol Initializer
+  (initialize! [this]
+    "Initialize a splitter, called everytime a new buffer is output
+     to reset internal state."))
+
+(defn bytes-needed
+  "Figure out how many bytes need to be read to finish this split."
+  [parser kept buf]
+  (let [kept-len (if (some? kept) (buf/readable-bytes kept) 0)]
+    (when-let [mark (header-length parser buf)]
+      (+ kept-len (payload-length parser mark kept buf)))))
+
+;;
+;; A header splitter, which depends on the help of a HeaderParser
+;; implementation to figure out expected size
+(defrecord HeaderSplitter [parser need kept]
+  Initializer
+  (initialize! [this]
+    (assoc this :need nil :kept nil))
+  ContentSplitter
+  (offer [this buf]
+    (let [kept-len  (if kept (buf/readable-bytes kept) 0)
+          buf-len   (buf/readable-bytes buf)
+          total-len (+ kept-len buf-len)
+          need      (or need (bytes-needed parser kept buf))]
+      (cond
+        (nil? need)
+        [(assoc this :kept (buf/augment-composite (or kept (buf/composite))
+                                                  (buf/read-retained-slice buf)))]
+
+        (and (number? need) (>= total-len need))
+        [(initialize! this)
+         (cond->> (buf/read-retained-slice buf (- need kept-len))
+           (some? kept) (buf/augment-composite kept))]
+
+        ::else
+        [(assoc this
+                :kept (buf/augment-composite (or kept (buf/composite))
+                                             (buf/read-retained-slice buf))
+                :need need)]))))
+
+(defn parse-split
+  "With a new buffer, augment a splitter by consuming all data from the
+   buffer. Yields a vector of the augmented splitter and a sequence of
+   new buffers to output, if any."
+  [stored buf]
+  (loop [splitter (first stored)
+         outbufs  []]
+    (let [[splitter outbuf] (offer splitter buf)
+          outbufs           (cond-> outbufs (some? outbuf) (conj outbuf))]
+      (if (buf/exhausted? buf)
+        [splitter outbufs]
+        (recur splitter outbufs)))))
+
+(defn raw-split
+  "A transducer that yields collections of ByteBuf instances, from
+   a collection of ByteBuf instances, splitting with the help of
+   a ContentSplitter implementation."
+  [splitter]
+  (fn [xf]
+    (let [sp (volatile! [(initialize! splitter)])]
+      (fn
+        ([] (xf))
+        ([result] (xf result))
+        ([result input]
+         (let [[splitter outbufs] (vswap! sp parse-split input)]
+           (buf/release input)
+           (if (seq outbufs)
+             (xf result outbufs)
+             result)))))))
+
+(defn split
+  "Facility function to create a splitter which yields a single
+   collection of ByteBuf instances."
+  [splitter]
+  (comp (raw-split splitter) cat))

--- a/test/net/transform/aggregator_test.clj
+++ b/test/net/transform/aggregator_test.clj
@@ -1,0 +1,29 @@
+(ns net.transform.aggregator-test
+  (:require [clojure.test :refer :all]
+            [net.transform.aggregator :refer :all]
+            [net.transform.helpers :refer :all]
+            [net.ty.buffer :as buf]))
+
+(deftest aggregating-buffers
+  (doseq [size [(mega-bytes 10) (mega-bytes 100)]
+          :let [path (create-temp-file size)]]
+    (doseq [agg-size  [(kilo-bytes 79) (mega-bytes 3) (mega-bytes 16)]
+            read-size [(kilo-bytes 33) (kilo-bytes 64)]
+            :let      [input   (lazy-bytes (input-stream path) read-size)
+                       output  (transduce (aggregator agg-size) add! {} input)
+                       inbufs  (bufcount size read-size)
+                       outbufs (bufcount size agg-size)]]
+      (testing (format "aggregating %d %d-byte chunks from %d bytes in %d bufs"
+                       outbufs agg-size size inbufs)
+        (is (= inbufs (count input)))
+        (is (= outbufs (:count output)))
+        (is (= size (:size output)))
+        (is (empty? (leaking-buffers input)))))
+    (delete-file path)))
+
+
+(deftest small-aggregation
+  (testing "small bufs"
+    (let [bufs (map buf/wrapped-bytes [(byte-array (repeat 200 (byte 0)))])
+          output (sequence (aggregator 1024) bufs)]
+      (is (= (count output) (count bufs))))))

--- a/test/net/transform/helpers.clj
+++ b/test/net/transform/helpers.clj
@@ -1,0 +1,109 @@
+(ns net.transform.helpers
+  (:require [net.ty.buffer :as buf])
+  (:import java.io.File
+           java.io.InputStream
+           java.io.OutputStream
+           java.nio.ByteBuffer
+           java.nio.channels.FileChannel
+           java.nio.file.attribute.FileAttribute
+           java.nio.file.Files
+           java.nio.file.FileSystems
+           java.nio.file.OpenOption
+           java.nio.file.Path
+           java.nio.file.StandardOpenOption))
+;; support functions
+;; =================
+
+(defn ^Path make-path
+  [root]
+  (.getPath (FileSystems/getDefault) root (into-array String [])))
+
+(def read-options
+  (into-array OpenOption [StandardOpenOption/READ]))
+
+(def write-options
+  (into-array OpenOption [StandardOpenOption/WRITE
+                          StandardOpenOption/CREATE
+                          StandardOpenOption/TRUNCATE_EXISTING]))
+
+(def file-attrs (into-array FileAttribute []))
+
+(defn create-temp-file
+  [sz]
+  (let [path ^Path (.toPath (doto (File/createTempFile "buftest" ".dat")
+                              (.deleteOnExit)))
+        chan ^FileChannel (FileChannel/open path write-options)]
+    (dotimes [i (quot sz 1024)]
+      (let [ba (byte-array (repeat 1024 (byte 0)))]
+        (.write chan (ByteBuffer/wrap ba))))
+    (.close chan)
+    (str path)))
+
+(defn delete-file
+  [path]
+  (-> path make-path .toFile .delete))
+
+(defn ^InputStream input-stream
+  [path]
+  (Files/newInputStream (make-path path) read-options))
+
+(defn ^OutputStream output-stream
+  [path]
+  (Files/newOutputStream (make-path path) write-options))
+
+(defn lazy-bytes
+  [^InputStream is bufsize]
+  (lazy-seq
+   (let [ba  (byte-array bufsize)
+         len (.read is ba)]
+     (if (neg? len)
+       (.close is)
+       (cons (doto (buf/direct-buffer len)
+               (buf/write-bytes ba 0 len))
+             (lazy-bytes is bufsize))))))
+
+(defn buf-statistics
+    [buf]
+    (loop [s ""
+           zeroes 0]
+      (if (buf/exhausted? buf)
+        {:visibile s :zeroes zeroes}
+        (let [c (buf/read-char buf)]
+          (if (zero? (byte c))
+            (recur s (inc zeroes))
+            (recur (str s c) zeroes))))))
+
+(def leaking-buffer-xf
+  (comp (map #(when (pos? (buf/refcount %)) (buf/showbuf %)))
+        (map-indexed vector)
+        (remove (comp nil? second))))
+
+(def leaking-buffers
+  (partial sequence leaking-buffer-xf))
+
+;;
+;;
+(def add!
+  (completing
+   (fn [res buf]
+     (let [rc (buf/refcount buf)
+           sz (if (pos? rc) (buf/readable-bytes buf) 0)]
+       (buf/skip-bytes buf)
+       (buf/release buf)
+
+       (-> res
+           (update :count (fnil inc 0))
+           (update :refcounts (fnil + 0) rc)
+           (update :size (fnil + 0) sz))))))
+
+(def kilo-bytes (partial * 1024))
+(def mega-bytes (partial kilo-bytes 1024))
+(def giga-bytes (partial mega-bytes 1024))
+
+(def one-kb (kilo-bytes 1))
+(def one-mb (mega-bytes 1))
+(def one-gb (giga-bytes 1))
+
+(defn bufcount
+  [size bufsize]
+  (cond-> (quot size bufsize) (pos? (rem size bufsize)) (+ 1)))


### PR DESCRIPTION
net exposes data as channels of ByteBuf instances in several places.
For instance, by default the body of Http requests will be exposed
in this manner.

When large request bodies are sent, there might be the need for
transforms to happen on the body without accumulating all ByteBuf
instances.

In this case, transducers which handle ByteBuf reference counting
are necessary.

This patch provides the foundation to build these transforms by
creating correctly counted CompositeByteBuf instances.