### PR TITLE
FIX(chunk): write-listener release ByteBuf when write-flush finished

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject spootnik/net "0.3.3-beta35"
+(defproject spootnik/net "0.3.3-beta36"
   :description "A clojure netty companion"
   :url "https://github.com/pyr/net"
   :license {:name "MIT License"

--- a/src/net/http/chunk.clj
+++ b/src/net/http/chunk.clj
@@ -129,7 +129,10 @@
                 http/last-http-content)]
       (f/add-listener (chan/write-and-flush! ctx msg)
                       (if (some? msg)
-                        listener
+                        (f/listen-with
+                         (fn [_ ftr]
+                           (buf/ensure-released msg)
+                           (.operationComplete listener ftr)))
                         chan/close-future)))))
 
 ;; A Netty ChannelFutureListener used when writing in chunks


### PR DESCRIPTION
No more leak when client disconnect without finishing reading 