### PR TITLE
tls: support sni in SSL handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Net now has full [API Documentation](http://pyr.github.io/net) and
 
 ## Changelog
 
+### 0.3.3-beta36
+
+- Support SNI for TLS requests
+
 ### 0.3.3-beta34
 
 - Add draining facilities for unexpectedly closed channels

--- a/deps.edn
+++ b/deps.edn
@@ -2,4 +2,4 @@
  :deps
  {org.clojure/clojure {:mvn/version "1.9.0"}
   org.clojure/core.async {:mvn/version "0.4.474"}
-  io.netty/netty-all {:mvn/version "4.1.21.Final"}}}
+  io.netty/netty-all {:mvn/version "4.1.22.Final"}}}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject spootnik/net "0.3.3-beta35"
+(defproject spootnik/net "0.3.3-beta36"
   :description "A clojure netty companion"
   :url "https://github.com/pyr/net"
   :license {:name "MIT License"
@@ -24,7 +24,7 @@
                    :jvm-opts       ["-Dio.netty.leakDetection.level=paranoid"]}}
   :dependencies [[org.clojure/clojure                      "1.9.0"]
                  [org.clojure/core.async                   "0.4.474"]
-                 [io.netty/netty-all                       "4.1.21.Final"]
+                 [io.netty/netty-all                       "4.1.22.Final"]
                  [io.netty/netty-tcnative                  "2.0.7.Final"]
                  [io.netty/netty-tcnative-boringssl-static "2.0.7.Final"]]
   :global-vars {*warn-on-reflection* true})

--- a/src/net/http/client.clj
+++ b/src/net/http/client.clj
@@ -82,7 +82,7 @@
 
 (defn request-initializer
   "Our channel initializer."
-  ([ssl? ssl-ctx handler transform]
+  ([ssl? ssl-ctx handler transform host port]
    (when (and ssl? (nil? ssl-ctx))
      (throw (IllegalArgumentException.
              "SSL was required but no SSL context is present")))
@@ -90,7 +90,7 @@
      (initChannel [^Channel channel]
        (-> (chan/pipeline channel)
            (cond-> ssl?
-             (p/add-last "ssl"   (ssl/new-handler ssl-ctx channel)))
+             (p/add-last "ssl"   (ssl/new-handler ssl-ctx channel host port)))
            (p/add-last "codec"   (HttpClientCodec.))
            (p/add-last "handler" (netty-handler handler transform)))))))
 
@@ -121,7 +121,7 @@
          port        (:port uri)
          host        (:host uri)
          transform   (:transform request-map)
-         initializer (request-initializer ssl? ssl-ctx handler transform)
+         initializer (request-initializer ssl? ssl-ctx handler transform host port)
          bs          (bs/bootstrap {:group   group
                                     :channel channel
                                     :handler initializer})

--- a/src/net/ssl.clj
+++ b/src/net/ssl.clj
@@ -145,8 +145,10 @@
 
 (defn ^ChannelHandler new-handler
   "Create a new SSL handler from an SslContext"
-  [^SslContext ctx ^Channel channel]
-  (.newHandler ctx (.alloc channel)))
+  ([^SslContext ctx ^Channel channel]
+   (.newHandler ctx (.alloc channel)))
+  ([^SslContext ctx ^Channel channel ^String host port]
+   (.newHandler ctx (.alloc channel) host (int port))))
 
 (defn ^clojure.lang.IFn handler-fn
   "Build a handler function to be used in netty pipelines out of an SSL context.


### PR DESCRIPTION
We previously did not indicate which server name we intended to reach in the TLS hello, leading
to odd behavior.