### PR TITLE
ADD: IdleStateHandler used to detect connection inactivity

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject spootnik/net "0.3.3-beta38"
+(defproject spootnik/net "0.3.3-beta39"
   :description "A clojure netty companion"
   :url "https://github.com/pyr/net"
   :license {:name "MIT License"


### PR DESCRIPTION
IdleStateHandler triggers an IdleStateEvent when a Channel has not performed read, write, or both operation for a while. 

https://netty.io/4.1/api/io/netty/handler/timeout/IdleStateHandler.html
