### PR TITLE
FIX(http-server): Pass ChannelOption correctly to server-bootstrap

### DIFF
--- a/src/net/http/server.clj
+++ b/src/net/http/server.clj
@@ -260,7 +260,7 @@
    (let [boss-group  (http/make-boss-group options)
          [host port] (get-host-port options)]
      (try
-       (let [bootstrap (bs/server-bootstrap {:config  (merge {:so-backlog 256 :so-reuseaddr true}
+       (let [bootstrap (bs/server-bootstrap {:options (merge {:so-backlog 256 :so-reuseaddr true}
                                                              (:bootstrap options))
                                              :group   boss-group
                                              :channel (if (or (:disable-epoll? options)


### PR DESCRIPTION
Options used to set ChannelOption was passed as `:config` key but this key is never used inside `server-bootstrap`

Options defined in `run-server` were not used.