### PR TITLE
travis: build on openjdk11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,9 @@ dist: trusty
 sudo: false
 language: clojure
 jdk:
-- openjdk7
-- oraclejdk7
 - openjdk8
 - oraclejdk8
+- openjdk11
 branches:
   except:
   - gh-pages

--- a/src/net/codec/b64.clj
+++ b/src/net/codec/b64.clj
@@ -1,23 +1,23 @@
 (ns net.codec.b64
   "Base64 encoding and decoding"
-  (:import javax.xml.bind.DatatypeConverter))
+  (:import java.util.Base64))
 
 (defn ^String b->b64
   "Convert a byte-array to base64"
   [^bytes b]
-  (-> b DatatypeConverter/printBase64Binary .trim))
+  (String. (.encode (Base64/getEncoder) b)))
 
 (defn ^String s->b64
   "Convert a string to base64"
   [^String s]
-  (-> s .getBytes b->b64))
+  (s->b64 (.getBytes s "UTF-8")))
 
 (defn ^"[B" b64->b
   ""
   [^String s]
-  (-> s DatatypeConverter/parseBase64Binary))
+  (.encode (Base64/getEncoder) (.getBytes s)))
 
 (defn ^String b64->s
   ""
   [^String s]
-  (-> s b64->b String. .trim))
+  (String. (b64->b)))

--- a/src/net/http/client.clj
+++ b/src/net/http/client.clj
@@ -49,7 +49,6 @@
            io.netty.handler.ssl.SslHandler
            java.net.URI
            java.nio.charset.Charset
-           javax.xml.bind.DatatypeConverter
            clojure.core.async.impl.protocols.Channel))
 
 (def default-inbuf 10)

--- a/src/net/ssl.clj
+++ b/src/net/ssl.clj
@@ -3,14 +3,14 @@
   (:require [net.ty.channel  :as chan]
             [net.ty.pipeline :refer [*channel*]]
             [clojure.java.io :refer [input-stream]])
-  (:import java.security.KeyStore
+  (:import java.util.Base64
+           java.security.KeyStore
            java.security.KeyFactory
            java.security.PrivateKey
            java.security.cert.X509Certificate
            java.security.cert.CertificateFactory
            java.security.spec.PKCS8EncodedKeySpec
            java.io.ByteArrayInputStream
-           javax.xml.bind.DatatypeConverter
            io.netty.channel.ChannelHandler
            io.netty.channel.Channel
            io.netty.handler.ssl.SslContext
@@ -54,7 +54,7 @@
     :else
     input))
 
-(defn cert-bytes
+(defn ^"[B" cert-bytes
   "Get certificate bytes out of an input."
   [input]
   (if (instance? (Class/forName "[B") input)
@@ -73,7 +73,7 @@
   Since these keys are usually DER encoded, they're unconvienent to
   have laying around in strings. We resort to base64 encoded DER here."
   [^KeyFactory factory input]
-  (let [bytes (DatatypeConverter/parseBase64Binary (cert-string input))
+  (let [bytes (.encode (Base64/getEncoder) (cert-bytes input))
         kspec (PKCS8EncodedKeySpec. bytes)]
     (.generatePrivate factory kspec)))
 


### PR DESCRIPTION
base64 encoding shouldn't rely on `javax.xml.bind` any more.