### PR TITLE
hex: fix exception...

### DIFF
--- a/src/net/codec/hex.clj
+++ b/src/net/codec/hex.clj
@@ -8,6 +8,6 @@
       (let [ba (.getBytes s)]
         (throw (ex-info "cannot parse input string as hex value"
                         {:sample  (vec (take 5 (seq ba)))
-                         :zeroes (reduce + 0 (remove zero?  ba))
-                         :str (reduce str (map char (remove zero? ba)))
-                         :size    (count (.getBytes s))}))))))
+                         :zeroes  (reduce + 0 (remove zero?  ba))
+                         :str     s
+                         :size    (count ba)}))))))


### PR DESCRIPTION
```clj
(hex->long "î")
```

**then**

> java.lang.IllegalArgumentException: Value out of range for char: -61

**now**

> cannot parse input string as hex value {:sample [-61 -82], :zeroes -143, :str "î", :size 2}