### PR TITLE
FIX(b64): b64-> methods should decode + s->b64 use b->b64 internaly

### DIFF
--- a/src/net/codec/b64.clj
+++ b/src/net/codec/b64.clj
@@ -10,14 +10,14 @@
 (defn ^String s->b64
   "Convert a string to base64"
   [^String s]
-  (s->b64 (.getBytes s "UTF-8")))
+  (b->b64 (.getBytes s "UTF-8")))
 
 (defn ^"[B" b64->b
   ""
   [^String s]
-  (.encode (Base64/getEncoder) (.getBytes s)))
+  (.decode (Base64/getDecoder) (.getBytes s)))
 
 (defn ^String b64->s
   ""
   [^String s]
-  (String. (b64->b)))
+  (String. (b64->b s)))


### PR DESCRIPTION
We have some errors in `b64` introduced when migrating to Java11
