### PR TITLE
notify-bad-request! called on invalid URI

### DIFF
--- a/src/net/http.clj
+++ b/src/net/http.clj
@@ -154,7 +154,7 @@
        :version        (-> msg .protocolVersion .text)
        :headers        hdrs})
     (catch Exception _
-      nil)))
+      ::unparsable-request)))
 
 (defn protocol-version
   [^HttpRequest msg]

--- a/src/net/http.clj
+++ b/src/net/http.clj
@@ -142,16 +142,19 @@
 (defn ->request
   "Create a request map from a Netty Http Request"
   [^HttpRequest msg]
-  (let [dx   (QueryStringDecoder. (str/replace (.uri msg) "+" "%20"))
-        hdrs (headers/as-map (.headers msg))
-        p1   (->params dx)]
-    {:uri            (.path dx)
-     :raw-uri        (.rawPath dx)
-     :get-params     p1
-     :params         p1
-     :request-method (method->data (.method msg))
-     :version        (-> msg .protocolVersion .text)
-     :headers        hdrs}))
+  (try
+    (let [dx   (QueryStringDecoder. (.uri msg))
+          hdrs (headers/as-map (.headers msg))
+          p1   (->params dx)]
+      {:uri            (.path dx)
+       :raw-uri        (.rawPath dx)
+       :get-params     p1
+       :params         p1
+       :request-method (method->data (.method msg))
+       :version        (-> msg .protocolVersion .text)
+       :headers        hdrs})
+    (catch Exception _
+      nil)))
 
 (defn protocol-version
   [^HttpRequest msg]

--- a/src/net/http/server.clj
+++ b/src/net/http/server.clj
@@ -149,9 +149,16 @@
         (cond
           (instance? HttpRequest msg)
           (let [request (http/->request msg)]
-            (if (bad? request)
+            (cond 
+              (bad? request)
               (notify-bad-request! handler msg ctx (:chan @state)
                                    "Trailing content on request")
+              
+              (nil? request)
+              (notify-bad-request! handler msg ctx (:chan @state)
+                                   "Invalid request")
+              
+              :else
               (let [in      (a/chan inbuf)
                     version (http/protocol-version msg)
                     bodyreq (assoc request

--- a/src/net/http/server.clj
+++ b/src/net/http/server.clj
@@ -154,9 +154,9 @@
               (notify-bad-request! handler msg ctx (:chan @state)
                                    "Trailing content on request")
               
-              (nil? request)
+              (= :net.http/unparsable-request request)
               (notify-bad-request! handler msg ctx (:chan @state)
-                                   "Invalid request")
+                                   "Unparsable request")
               
               :else
               (let [in      (a/chan inbuf)

--- a/test/net/http_test.clj
+++ b/test/net/http_test.clj
@@ -61,9 +61,14 @@
                    :uri            (str "http://localhost:" port)
                    :transform      st/transform})
              success-response)))
+    (testing "uri with + supported"
+      (doseq [[uri resp] [["/gong-site-bucket/gong-team-logo-2020.jpg?mtime=20210204200512&focal=50.92+26" success-response "Handle + in URI"]
+                          ["/gong-site-bucket/gong-team-logo-2020.jpg?mtime=20210204200512&focal=50.92%2026" success-response "Handle %20 in URI"]]]
+        (is (= resp
+               (req {:request-method :get
+                     :uri            (str "http://localhost:" port uri)
+                     :transform      st/transform})))))
     (server)))
-
-
 
 (deftest error-tests
   (is (thrown-with-msg?


### PR DESCRIPTION
I do not manage to generate invalid URI in tests using `net.http.client` or `clj-http` because they will fail to parse the URI