### PR TITLE
Fix invalid request

### DIFF
--- a/examples/server/echo_http.clj
+++ b/examples/server/echo_http.clj
@@ -1,6 +1,5 @@
 (ns server.echo-http
   (:require [net.http.server       :as http]
-            [net.ty.buffer         :as buf]
             [clojure.core.async    :as a]
             [clojure.tools.logging :refer [info]]))
 

--- a/project.clj
+++ b/project.clj
@@ -27,4 +27,6 @@
                  [io.netty/netty-all                       "4.1.33.Final"]
                  [io.netty/netty-tcnative                  "2.0.22.Final"]
                  [io.netty/netty-tcnative-boringssl-static "2.0.22.Final"]]
+  :test-selectors {:default (complement :ignore)
+                   :ignore :ignore}
   :global-vars {*warn-on-reflection* true})

--- a/src/net/http/client.clj
+++ b/src/net/http/client.clj
@@ -62,7 +62,8 @@
         :body    body})
     (finally
       ;; This actually releases the content
-      (buf/release (buf/as-buffer msg)))))
+      (when (satisfies? buf/Bufferizable msg)
+        (buf/release (buf/as-buffer msg))))))
 
 (defn ^ChannelInboundHandlerAdapter netty-handler
   "Simple netty-handler, everything may happen in

--- a/src/net/http/server.clj
+++ b/src/net/http/server.clj
@@ -161,7 +161,8 @@
                                 (when chan
                                   (a/close! chan)))]
           (cond
-            ;; When it's a new HTTP request, we are creating a core/async and we are passing it to the handler.
+            ;; When it's a new HTTP request, we are creating a core/async channel and
+            ;; we are passing it to the handler.
             (instance? HttpRequest msg)
             (let [request (http/->request msg)
                   version (http/protocol-version msg)]

--- a/src/net/http/server.clj
+++ b/src/net/http/server.clj
@@ -123,7 +123,9 @@
             :request-method :error
             :ctx            ctx}))
 
-(defn reject-invalid-request [ctx version]
+(defn reject-invalid-request [ctx msg version]
+  (when (satisfies? buf/Bufferizable msg)
+    (buf/release (buf/as-buffer msg)))
   (let [resp (DefaultFullHttpResponse. version
                                        HttpResponseStatus/REQUEST_URI_TOO_LONG)]
     (f/with-result [ftr (chan/write-and-flush! ctx resp)]
@@ -169,7 +171,7 @@
 
               (cond
                 (= :net.http/unparsable-request request)
-                (reject-invalid-request ctx version)
+                (reject-invalid-request ctx msg version)
 
                 (bad? request)
                 (notify-bad-request! handler msg ctx nil "Trailing content on request")

--- a/test/net/http_test.clj
+++ b/test/net/http_test.clj
@@ -130,7 +130,7 @@
 
 (def invalid-uri "file.jpg?mtime=20210218162931&focal=30.92%%2050.13%&tmtime=20210324130011")
 
-(deftest bad-requests
+(deftest bad-request-invalid-uri
   (let [port (get-port)
         server (server/run-server {:port port} (constantly 42))]
     (testing "invalid uri"
@@ -144,6 +144,11 @@
            :headers {}
            :version "HTTP/1.1"
            :body ""})))
+    (server)))
+
+(deftest bad-request-invalid-uri-chunked
+  (let [port (get-port)
+        server (server/run-server {:port port} (constantly 42))]
     (testing "invalid uri + chunked"
       (is
        (= (raw-req {:request-method :post
@@ -158,7 +163,6 @@
            :version "HTTP/1.1"
            :body ""})))
     (server)))
-
 
 (deftest ->request-test
   (testing "invalid uri"

--- a/test/net/http_test.clj
+++ b/test/net/http_test.clj
@@ -1,6 +1,7 @@
 (ns net.http-test
   (:require [net.http.client      :as client]
             [net.http.server      :as server]
+            [net.http             :as http]
             [net.ty.buffer        :as buf]
             [net.transform.string :as st]
             [clojure.core.async   :as a]
@@ -23,11 +24,11 @@
   (constantly success-response))
 
 (defn echo-handler
-  [{:keys [body headers] :as request}]
+  [{:keys [body headers]}]
   (assoc success-response
          :body    body
          :headers {:connection     "close"
-                   :content-length (:content-length headers)}))
+                   :content-length (or (:content-length headers) 0)}))
 
 (defn req
   [payload]
@@ -76,3 +77,26 @@
        #"SSL was required but no SSL context is present"
        (client/request nil {:request-method :get
                             :uri "https://foo.example.com"}))))
+
+(defn http-request [uri]
+  (reify io.netty.handler.codec.http.HttpRequest
+    (uri [this] uri)
+    (headers [this] (io.netty.handler.codec.http.HttpHeaders/EMPTY_HEADERS))
+    (method [this] (io.netty.handler.codec.http.HttpMethod/GET))
+    (protocolVersion [this] (io.netty.handler.codec.http.HttpVersion/HTTP_1_1))))
+
+(def invalid-uri "file.jpg?mtime=20210218162931&focal=30.92%%2050.13%&tmtime=20210324130011")
+
+(deftest ->request-test
+  (testing "invalid uri"
+    (is (= :net.http/unparsable-request
+           (http/->request (http-request invalid-uri)))))
+  (testing "valid uri"
+    (is (= {:uri "/file1",
+            :raw-uri "/file1",
+            :get-params {},
+            :params {},
+            :request-method :get,
+            :version "HTTP/1.1",
+            :headers {}}
+           (http/->request (http-request "/file1"))))))


### PR DESCRIPTION
## Description

This PR is supposed to fix the following raised Exception when a client is sending a `Transfer-encoding: chunked` with an invalid URI.

```clojure
No implementation of method: :put! of protocol: #'clojure.core.async.impl.protocols/WritePort found for class: nil
```

Two integration tests have been added:
- One with an invalid URI
- One with an invalid URI with transfer-encoding: chunked (not passing)